### PR TITLE
[GIF-48]. Missing info to display complete location.

### DIFF
--- a/restui/serializers/mappings.py
+++ b/restui/serializers/mappings.py
@@ -127,6 +127,7 @@ class MappingsSerializer(serializers.Serializer):
                             'upi':mapping.transcript.uniparc_accession,
                             'biotype':mapping.transcript.biotype,
                             'deleted':mapping.transcript.deleted,
+                            'chromosome':mapping.transcript.gene.chromosome,
                             'seqRegionStart':mapping.transcript.seq_region_start,
                             'seqRegionEnd':mapping.transcript.seq_region_end,
                             'ensgId':mapping.transcript.gene.ensg_id,


### PR DESCRIPTION
This adds chromosome to the transcript part of the serialized mapping.

Note: Carlos hasn't yet loaded this information 