### PR TITLE
[GIF-97]. Alignment API

### DIFF
--- a/restui/serializers/alignments.py
+++ b/restui/serializers/alignments.py
@@ -1,0 +1,18 @@
+from restui.models.mappings import Alignment, AlignmentRun #, Mapping, MappingHistory, ReleaseMappingHistory
+
+from rest_framework import serializers
+
+class AlignmentRunSerializer(serializers.ModelSerializer):
+    """
+    Serialize an AlignmentRun instance
+    """
+    
+    class Meta:
+        model = AlignmentRun
+        fields = '__all__'
+        
+class AlignmentSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Alignment
+        fields = '__all__'

--- a/restui/urls.py
+++ b/restui/urls.py
@@ -5,7 +5,8 @@ from restui.views import alignments, ensembl, mappings
 urlpatterns = [
     path('alignments/alignment_run/<int:pk>/', alignments.AlignmentRunFetch.as_view()), # retrieve alignment run by ID (GET)
     path('alignments/alignment_run/', alignments.AlignmentRunCreate.as_view()),         # insert alignment run (POST),
-#     path('alignments/alignment/latest/assembly/<assembly_accession>/', alignments.LatestAlignmentsFetch.as_view()), # retrieve latest alignments by assembly accession (GET)
+    path('alignments/alignment/latest/assembly/<assembly_accession>/',                  # retrieve latest alignments by assembly accession (GET)
+         alignments.LatestAlignmentsFetch.as_view()),                                   #   param: alignment_type: perfect_match (default), identity
     path('alignments/alignment/<int:pk>/', alignments.AlignmentFetch.as_view()),        # retrieve alignment by ID (GET)
     path('alignments/alignment/', alignments.AlignmentCreate.as_view()),                # insert alignment (POST)
     # path('alignments/perfect_matches/'), # fetch_latest_uniprot_enst_perfect_matches

--- a/restui/urls.py
+++ b/restui/urls.py
@@ -6,8 +6,8 @@ urlpatterns = [
     path('alignments/alignment_run/<int:pk>/', alignments.AlignmentRunFetch.as_view()), # retrieve alignment run by ID (GET)
     path('alignments/alignment_run/', alignments.AlignmentRunCreate.as_view()),         # insert alignment run (POST),
 #     path('alignments/alignment/latest/assembly/<assembly_accession>/', alignments.LatestAlignmentsFetch.as_view()), # retrieve latest alignments by assembly accession (GET)
-#     path('alignments/alignment/<int:pk>/', alignments.AlignmentFetch.as_view()),           # retrieve alignment by ID (GET)
-#     path('alignments/alignment/', alignments.AlignmentCreate.as_view()),                   # insert alignment (POST)
+    path('alignments/alignment/<int:pk>/', alignments.AlignmentFetch.as_view()),        # retrieve alignment by ID (GET)
+    path('alignments/alignment/', alignments.AlignmentCreate.as_view()),                # insert alignment (POST)
     # path('alignments/perfect_matches/'), # fetch_latest_uniprot_enst_perfect_matches
     
     path('ensembl/load/<species>/<assembly_accession>/<int:ensembl_tax_id>/<int:ensembl_release>/', ensembl.EnsemblFeature.as_view()),

--- a/restui/urls.py
+++ b/restui/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
 from django.conf.urls import url
-from restui.views import ensembl, mappings
+from restui.views import alignments, ensembl, mappings
 
 urlpatterns = [
-#     path('alignments/alignment_run/<int:pk>/', alignments.AlignmentRunFetch.as_view()),    # retrieve alignment run by ID (GET)
-#     path('alignments/alignment_run/', alignments.AlignmentRunCreate.as_view()),            # insert alignment run (POST),
+    path('alignments/alignment_run/<int:pk>/', alignments.AlignmentRunFetch.as_view()), # retrieve alignment run by ID (GET)
+    path('alignments/alignment_run/', alignments.AlignmentRunCreate.as_view()),         # insert alignment run (POST),
 #     path('alignments/alignment/latest/assembly/<assembly_accession>/', alignments.LatestAlignmentsFetch.as_view()), # retrieve latest alignments by assembly accession (GET)
 #     path('alignments/alignment/<int:pk>/', alignments.AlignmentFetch.as_view()),           # retrieve alignment by ID (GET)
 #     path('alignments/alignment/', alignments.AlignmentCreate.as_view()),                   # insert alignment (POST)

--- a/restui/views/alignments.py
+++ b/restui/views/alignments.py
@@ -39,3 +39,27 @@ class AlignmentFetch(generics.RetrieveAPIView):
     queryset = Alignment.objects.all()
     serializer_class = AlignmentSerializer
 
+class LatestAlignmentsFetch(generics.ListAPIView):
+    """
+    Retrieve either perfect or blast latest alignments for a given assembly
+    """
+
+    serializer_class = AlignmentSerializer
+    pagination_class = PageNumberPagination
+    
+    def get_queryset(self):
+        assembly_accession = self.kwargs["assembly_accession"]
+
+        # alignment type must be either 'identity' or 'perfect_match', default to latter
+        alignment_type = self.request.query_params.get('type', 'perfect_match')
+        if not alignment_type in ('identity', 'perfect_match'):
+            raise Http404('Invalid alignment type')
+
+        try:
+            alignment_run = AlignmentRun.objects.filter(release_mapping_history__ensembl_species_history__assembly_accession__iexact=assembly_accession,
+                                                        score1_type=alignment_type).order_by('-time_run')[0]
+        except (AlignmentRun.DoesNotExist, IndexError):
+            raise Http404
+        
+        return Alignment.objects.filter(alignment_run=alignment_run)
+    

--- a/restui/views/alignments.py
+++ b/restui/views/alignments.py
@@ -1,0 +1,26 @@
+import pprint
+
+from restui.models.mappings import Alignment, AlignmentRun
+from restui.serializers.alignments import AlignmentSerializer, AlignmentRunSerializer
+
+from django.http import Http404
+
+from rest_framework.views import APIView
+from rest_framework import generics
+from rest_framework.pagination import PageNumberPagination
+
+class AlignmentRunCreate(generics.CreateAPIView):
+    """
+    Store an AlignmentRun 
+    """
+
+    serializer_class = AlignmentRunSerializer
+
+class AlignmentRunFetch(generics.RetrieveAPIView):
+    """
+    Retrieve an AlignmentRun
+    """
+
+    queryset = AlignmentRun.objects.all()
+    serializer_class = AlignmentRunSerializer
+    

--- a/restui/views/alignments.py
+++ b/restui/views/alignments.py
@@ -24,3 +24,18 @@ class AlignmentRunFetch(generics.RetrieveAPIView):
     queryset = AlignmentRun.objects.all()
     serializer_class = AlignmentRunSerializer
     
+class AlignmentCreate(generics.CreateAPIView):
+    """
+    Insert an Alignment
+    """
+
+    serializer_class = AlignmentSerializer
+
+class AlignmentFetch(generics.RetrieveAPIView):
+    """
+    Retrieve an Alignment
+    """
+
+    queryset = Alignment.objects.all()
+    serializer_class = AlignmentSerializer
+


### PR DESCRIPTION
Endpoints to:
- fetch/insert alignments, alignment runs
- fetch latest alignments by assembly accession and type (perfect match | identity)

An additional endpoint, i.e. retrieve Uniprot-Ensembl perfect matches by species/accession, is probably needed, but need to discuss the details with Carlos.