### PR TITLE
EA-363 - Add endpoint to return version number

### DIFF
--- a/gifts_rest/settings/base.py
+++ b/gifts_rest/settings/base.py
@@ -36,7 +36,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Custom User model for the service
 AUTH_USER_MODEL = 'aap_auth.AAPUser'
 
-API_VERSION = '1'
+API_VERSION = '1.0.0'
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/

--- a/gifts_rest/settings/base.py
+++ b/gifts_rest/settings/base.py
@@ -36,6 +36,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Custom User model for the service
 AUTH_USER_MODEL = 'aap_auth.AAPUser'
 
+API_VERSION = '1'
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 

--- a/restui/serializers/version.py
+++ b/restui/serializers/version.py
@@ -1,0 +1,25 @@
+"""
+.. See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+from rest_framework import serializers
+
+
+class VersionSerializer(serializers.Serializer):
+    """
+    Version serializer
+    """
+    version = serializers.FloatField()

--- a/restui/serializers/version.py
+++ b/restui/serializers/version.py
@@ -22,4 +22,4 @@ class VersionSerializer(serializers.Serializer):
     """
     Version serializer
     """
-    version = serializers.FloatField()
+    version = serializers.CharField(required=True)

--- a/restui/tests.py
+++ b/restui/tests.py
@@ -35,6 +35,7 @@ from restui.lib import alignments
 from restui.lib import external
 from restui.views import mappings
 from restui.views import unmapped
+from restui.views import version
 
 
 FIXTURES = [
@@ -1016,3 +1017,14 @@ class LibExternal(APITestCase):
     def test_ensembl_protein(self):
         prot = external.ensembl_protein('ENST00000382038', 95)
         self.assertEqual(prot, 'ENSP00000371469')
+
+class APIVersion(APITestCase):
+    """
+    Tests for endpoint /api/version/
+    """
+
+    def test_api_version(self):
+        client = APIClient()
+        response = client.get('/api/version/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(isinstance(response.data['version'], float), True)

--- a/restui/tests.py
+++ b/restui/tests.py
@@ -1027,4 +1027,4 @@ class APIVersion(APITestCase):
         client = APIClient()
         response = client.get('/api/version/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(isinstance(response.data['version'], float), True)
+        self.assertRegex(response.data['version'], r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")

--- a/restui/urls.py
+++ b/restui/urls.py
@@ -25,6 +25,7 @@ from restui.views import mappings
 from restui.views import uniprot
 from restui.views import unmapped
 from restui.views import service
+from restui.views import version
 
 
 @csrf_exempt
@@ -177,7 +178,9 @@ urlpatterns = [
     path('unmapped/<int:taxid>/<source>/', unmapped.UnmappedEntries.as_view()),
 
     # return service status
-    path('service/ping/', service.PingService.as_view())
+    path('service/ping/', service.PingService.as_view()),
+
+    path('api/version/', version.APIVersion.as_view())
 ]
 
 """

--- a/restui/views/version.py
+++ b/restui/views/version.py
@@ -1,0 +1,34 @@
+"""
+.. See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+from django.conf import settings
+from restui.serializers.version import VersionSerializer
+
+
+class APIVersion(APIView):
+    """
+    Return API version
+    """
+
+    def get(self, request):
+        serializer = VersionSerializer(
+            {'version': settings.API_VERSION}
+        )
+        return Response(serializer.data)


### PR DESCRIPTION
Implemented an endpoint which returns backend's API version.
The main use-case is to easily compare API versions on Dev, Test and Prod services. 